### PR TITLE
Add information for the Recommended Versions

### DIFF
--- a/content/opensource_packages/dav1d.md
+++ b/content/opensource_packages/dav1d.md
@@ -18,10 +18,10 @@ optional_info:
         partner_content: 
         official_docs: https://github.com/videolan/dav1d/blob/master/README.md
     arm_recommended_minimum_version:
-        version_number:
-        release_date:
-        reference_content:
-        rationale:
+        version_number: 1.5.1
+        release_date: 2025/01/20
+        reference_content: https://github.com/videolan/dav1d/blob/master/NEWS
+        rationale: This version delivers performance and stability improvements with a focus on stack reduction and Arm optimizations. The loop restoration filters (SGR and Wiener) have been rewritten to significantly lower stack usage, reducing it to 58 KB on Arm and Aarch64. Key enhancements include improved loop restoration performance on Arm32 and Arm64, a new NEON-based implementation of load_tmvs for Aarch64, and overall efficiency gains. Additionally, the release addresses a rare potential deadlock issue in flush() to improve stability.
 
 optional_hidden_info:
     release_notes__supported_minimum:

--- a/content/opensource_packages/gromacs.md
+++ b/content/opensource_packages/gromacs.md
@@ -2,7 +2,7 @@
 name: Gromacs
 category: HPC
 description: Free and open-source software suite for high-performance molecular dynamics and output analysis
-download_url: https://www.gromacs.org/
+download_url: https://manual.gromacs.org/current/download.html
 works_on_arm: true
 supported_minimum_version:
     version_number: 5.1
@@ -16,12 +16,12 @@ optional_info:
     getting_started_resources:
         arm_content: 
         partner_content: 
-        official_docs: https://manual.gromacs.org/
+        official_docs: https://manual.gromacs.org/current/install-guide/index.html
     arm_recommended_minimum_version:
-        version_number:
-        release_date:
-        reference_content:
-        rationale:
+        version_number: 2025.1
+        release_date: 2025/03/11
+        reference_content: https://manual.gromacs.org/2025.1/release-notes/2025/2025.1.html
+        rationale:  This version corrects SIMD instruction guidance for Neoverse-V2 CPUs by recommending NEON over SVE where appropriate, ensuring better runtime performance. Compiler warnings related to Arm SVE have been silenced, resulting in a cleaner and more stable build experience.
 
 optional_hidden_info:
     release_notes__supported_minimum: https://manual.gromacs.org/documentation/5.1/ReleaseNotes/index.html

--- a/content/opensource_packages/macs2.md
+++ b/content/opensource_packages/macs2.md
@@ -18,14 +18,14 @@ optional_info:
         partner_content:
         official_docs: https://macs3-project.github.io/MACS/docs/INSTALL.html
     arm_recommended_minimum_version:
-        version_number:
-        release_date:
-        reference_content:
-        rationale:
+        version_number: 2.2.8
+        release_date: 2023/05/15
+        reference_content: https://github.com/macs3-project/MACS/releases/tag/v2.2.8
+        rationale: This version adds support for Python versions 3.6 through 3.11, along with compatibility for newer versions of NumPy and Cython. The updates have been tested on both x86 and Arm platforms, ensuring reliable performance on Linux Arm64 systems.
  
 optional_hidden_info:
     release_notes__supported_minimum:
     release_notes__recommended_minimum:
-    other_info: Successfully installed minimum version available(2.0.10.07022012) in relese page for Arm64 platform.
+    other_info: Initial Linux/Arm64 support isn't available in the release notes. Successfully installed minimum version available (2.0.10.07022012) from the release page on Arm.
  
 ---

--- a/content/opensource_packages/netbsd.md
+++ b/content/opensource_packages/netbsd.md
@@ -18,10 +18,10 @@ optional_info:
         partner_content:
         official_docs: https://www.netbsd.org/docs/guide/en/part-install.html
     arm_recommended_minimum_version:
-        version_number:
-        release_date:
-        reference_content:
-        rationale:
+        version_number: 10.0
+        release_date: 2024/03/28
+        reference_content: https://www.netbsd.org/releases/formal-10/NetBSD-10.0.html
+        rationale: This version significantly improves performance and support for Arm/Aarch64 systems. The scheduler now better handles big.LITTLE cores, and Aarch64 I/O and networking performance has been greatly optimized. Cryptographic algorithms like AES and ChaCha now use CPU acceleration and constant-time execution for added security. Key Armv8-A features—PAN, PAC, and BTI—are now supported to strengthen memory safety and ROP protection. Linux binary compatibility is now available on Aarch64 via compat_linux(8). Virtualization support has been extended to VMware ESXi-Arm and Oracle Cloud. UEFI bootloader improvements and expanded device driver support further enhance the Arm user experience.
 
 
 optional_hidden_info:

--- a/content/opensource_packages/suse.md
+++ b/content/opensource_packages/suse.md
@@ -18,10 +18,10 @@ optional_info:
         partner_content:
         official_docs: https://documentation.suse.com/sles/15-SP5/
     arm_recommended_minimum_version:
-        version_number: 15 SP3
-        release_date: 2024/11/20
-        reference_content: https://www.suse.com/releasenotes/aarch64/SUSE-SLES/15-SP3/index.html
-        rationale: SUSE Linux Enterprise Server for Arm 15 SP3 adds a kernel flavor 64kb, offering a page size of 64 KiB and physical/virtual address size of 52 bits. Main purpose at this time is to allow for side-by-side benchmarking for High Performance Computing, Machine Learning and other Big Data use cases. Starting from 12 SP5, official Vagrant Boxes for SUSE Linux Enterprise Server x86-64 and AArch64 using the VirtualBox and libvirt providers have been released, and continued. 15 SP3 includes driver enablement for the AWS Graviton, Graviton2 System-on-Chip (SoC) chipsets, and more. 15 SP3 kernel updates the Arm Generic Interrupt Controller (GIC) driver irq-gic-v4 to prepare for upcoming chips with GIC version 4.1.
+        version_number: 15 SP5
+        release_date: 2025/07/18
+        reference_content: https://www.suse.com/c/simple-vm-management-on-ampere-infrastructure/
+        rationale: SUSE Virtualization 1.5 brings full GA support for VM management on Arm64-based Kubernetes clusters running on Ampere infrastructure. With SLES 15 SP5 as the underlying OS, users gain not only compatibility but also efficiency—thanks to its support for 64K kernel page sizes. This combination provides a high-performance foundation for virtualization on Arm64, making SUSE Virtualization 1.5 both production-ready and cloud-native friendly.
 
 optional_hidden_info:
     release_notes__supported_minimum:  https://www.suse.com/releasenotes/aarch64/SUSE-SLES/12-SP2/index.html

--- a/content/opensource_packages/vectorscan.md
+++ b/content/opensource_packages/vectorscan.md
@@ -18,10 +18,10 @@ optional_info:
         partner_content:
         official_docs:
     arm_recommended_minimum_version:
-        version_number: 
-        release_date:
-        reference_content:
-        rationale:
+        version_number: 5.4.8
+        release_date: 2022/09/13
+        reference_content: https://github.com/VectorCamp/vectorscan/releases/tag/vectorscan%2F5.4.8
+        rationale: This version delivers a notable performance boost on Arm, achieving 5–10% faster execution compared to version 5.4.7, and 10–20% gains on Power architectures. Key updates include NEON-based optimizations for Aarch64, improved shift/align primitives, use of efficient instructions like shrn, and various build and compatibility fixes such as improved CMake configuration and proper handling of PCRE downloads.
 
 optional_hidden_info:
     release_notes__supported_minimum: https://github.com/VectorCamp/vectorscan/releases/tag/vectorscan%2F5.4.6

--- a/content/opensource_packages/xen_ci.md
+++ b/content/opensource_packages/xen_ci.md
@@ -18,10 +18,10 @@ optional_info:
         partner_content: 
         official_docs: https://xenproject.org/developers/getting-started-devs/
     arm_recommended_minimum_version:
-        version_number: 
-        release_date:
-        reference_content:
-        rationale:
+        version_number: 4.20.0
+        release_date: 2025/03/05
+        reference_content: https://github.com/xen-project/xen/blob/master/CHANGELOG.md#4200---2025-03-05
+        rationale: This version introduces several improvements for Arm platforms, particularly enhancing FF-A (Firmware Framework for Arm) support by adding indirect message handling, RXTX buffer transmission to the SPMC, and fixes for version negotiation and partition info retrieval. Experimental support for Armv8-R architecture has been added, along with support for the NXP S32G3 processor family and the LINFlexD UART driver. Additionally, SCMI requests over SMC using Shared Memory can now be forwarded to EL3 firmware when originating from hardware domains. The update also enables CONFIG_UBSAN in GitLab CI for Arm64 and other architectures, and introduces support for LLC (Last Level Cache) coloring to improve cache partitioning control on supported hardware.
 
 
 optional_hidden_info:

--- a/content/opensource_packages/zstandard.md
+++ b/content/opensource_packages/zstandard.md
@@ -18,10 +18,10 @@ optional_info:
         partner_content:
         official_docs: https://python-zstandard.readthedocs.io/en/latest/
     arm_recommended_minimum_version:
-        version_number: 
-        release_date: 
-        reference_content:
-        rationale: 
+        version_number: 0.22.0
+        release_date: 2023/11/01
+        reference_content: https://github.com/indygreg/python-zstandard/releases/tag/0.22.0
+        rationale: Binary wheels for musllinux_1_1 x86_64 and Aarch64 are being built and published from this version. That means, Arm64 users on musl-based Linux distros (like Alpine) will now have much easier and faster installs of this Python package.
 
 
 optional_hidden_info:


### PR DESCRIPTION
Updated the metadata for the recommended versions for the following packages:

1. Dav1d
2. Gromacs
3. Macs2
4. NetBSD
5. Vectorscan
6. Xen CI
7. Zstandard
8. Updated the Recommended Version for : SUSE

Signed-off-by: odidev <odidev@puresoftware.com>
