### PR TITLE
Add Greenhouse and OpenMCP Control Plane Operator

### DIFF
--- a/content/linux/opensource_packages/greenhouse.md
+++ b/content/linux/opensource_packages/greenhouse.md
@@ -1,0 +1,31 @@
+---
+name: Greenhouse
+category: Monitoring/Observability
+description: Greenhouse is a cloud operations platform that provides a unified interface to manage and automate large-scale distributed infrastructure, improving visibility, standardization, and operational efficiency.
+download_url: https://github.com/cloudoperators/greenhouse/releases
+works_on_arm: true
+supported_minimum_version:
+    version_number: 0.4.0
+    release_date: 2025/06/12
+ 
+ 
+optional_info:
+    homepage_url: https://cloudoperators.github.io/greenhouse/
+    support_caveats:
+    alternative_options:
+    getting_started_resources:
+        official_docs: https://cloudoperators.github.io/greenhouse/docs/
+        arm_content:
+        partner_content:
+    arm_recommended_minimum_version:
+        version_number:
+        release_date:
+        reference_content:
+        rationale:
+ 
+optional_hidden_info:
+    release_notes__supported_minimum:
+    release_notes__recommended_minimum:
+    other_info: Release notes for the initial Linux/Arm64 support isn't available. Linux/Arm64 artifacts are available from version 0.4.0 onwards on the GitHub releases.
+ 
+---

--- a/content/linux/opensource_packages/openmcp-control-plane-operator.md
+++ b/content/linux/opensource_packages/openmcp-control-plane-operator.md
@@ -1,0 +1,31 @@
+---
+name: OpenMCP Control Plane Operator
+category: Containers and Orchestration
+description: Control Plane Operator (part of the openMCP project) is a Kubernetes operator that automates the lifecycle management of components in a cluster by exposing a ControlPlane API and reconciling configured components on target clusters.
+download_url: https://github.com/openmcp-project/control-plane-operator/pkgs/container/images%2Fcontrol-plane-operator
+works_on_arm: true
+supported_minimum_version:
+    version_number: 0.1.6
+    release_date: 2025/05/23
+ 
+ 
+optional_info:
+    homepage_url: https://github.com/openmcp-project/control-plane-operator
+    support_caveats:
+    alternative_options:
+    getting_started_resources:
+        official_docs: https://github.com/openmcp-project/control-plane-operator#using-the-control-plane-operator-in-a-managed-setup
+        arm_content:
+        partner_content:
+    arm_recommended_minimum_version:
+        version_number:
+        release_date:
+        reference_content:
+        rationale:
+ 
+optional_hidden_info:
+    release_notes__supported_minimum:
+    release_notes__recommended_minimum:
+    other_info: Release notes for the initial Linux/Arm64 support isn't available. Linux/Arm64 container images are available from version 0.1.6 onwards.
+ 
+---


### PR DESCRIPTION
1. Added content/linux/opensource_packages/greenhouse.md file
2. Added content/linux/opensource_packages/openmcp-control-plane-operator.md file

Signed-off-by: odidev <odidev@puresoftware.com>